### PR TITLE
Morph Pluggable.__init__ into a __new__

### DIFF
--- a/docs/plugins_configuration.rst
+++ b/docs/plugins_configuration.rst
@@ -174,7 +174,6 @@ definition of an "implementation" (see
 
        def __init__(self, paramA: int = 1, paramB: int = 2) -> None:
            """Implementation constructor."""
-           super().__init__()  # at least imposed by Pluggable parent class.
            ...
 
        # Abstract methods from Configurable.

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -5,6 +5,12 @@ SMQTK-Core Pending Release Notes
 Updates / New Features
 ----------------------
 
+Pluggable
+
+* Removed `__init__` method and added a `__new__` in its place. The behavior is
+  the same, but is now less fragile from override and addresses some issues
+  with type-checking during some multiple inheritance situations.
+
 Misc.
 
 * Now standardize to using `Poetry`_ for environment/build/publish management.

--- a/smqtk_core/plugin.py
+++ b/smqtk_core/plugin.py
@@ -351,7 +351,7 @@ class Pluggable(metaclass=abc.ABCMeta):
     Interface for classes that have plugin implementations.
 
     This mixin class adds an assertive check during instance construction that
-    the derived type is "usable" by invoking it's `is_usable()` class-method
+    the derived type is "usable" by invoking its `is_usable()` class-method
     within this type's `__new__` method.
     This is happening in `__new__` specifically for a couple reasons:
 
@@ -364,8 +364,8 @@ class Pluggable(metaclass=abc.ABCMeta):
     **NOTE:** In a multiple inheritance scenario with another type that also
     implements `__new__`, this class should be listed to the right-hand-side
     so as to be later in the MRO. Otherwise, this will cut off arguments from
-    being to the super `__new__` as we simply consider the locally parent type
-    of `object` when calling our `super().__new__`.
+    being sent to the super `__new__` as we simply consider the locally parent
+    type of `object` when calling our `super().__new__`.
     """
 
     __slots__ = ()
@@ -432,7 +432,7 @@ class Pluggable(metaclass=abc.ABCMeta):
 
     def __new__(cls: Type[P], *args: Any, **kwargs: Any) -> P:
         # This needs to take in *args/**kwargs as a basic (not-new-overriding)
-        # subclass scenario will see it's constructor args passed here.
+        # subclass scenario will see its constructor args passed here.
         # Requiring all inheriting classes to define a __new__ for parameter
         # translation is unacceptable.
         if not cls.is_usable():


### PR DESCRIPTION
Change definition of `__init__` in Pluggable mixin into a `__new__` definition.

This change is motivated by a couple things:

  * Primarily: Unblocks certain type-checking situations involving multiple inheritance and behavior as a mixin.
  * Secondarily: Sub-classes do not have to explicitly invoke super to inherit this safety functionality.

This was motivated while working on a separate breakout module that first uses Pluggable in a pure-mixing capability, as well as with an optional dependency.
I was finding that mypy would not abate in throwing a `error: Unexpected keyword argument "..." for "..."`.
This led me to also realizing how annoying it was to "have" to call the super constructor for the mixin to effect its usability assert behavior that didn't need any instance-level details.

This change is backwards compatible in classes that were nominally behaving in the first place, i.e. weren't intentionally skipping a super call due to some weird reason they wanted to suppress the usability assert.

I locally tested this update with all currently broken out `smqtk-*` modules resulting in successfully passing flake8/mypy/pytest checks.