### PR TITLE
Added some example documentation around configuration

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -5,6 +5,12 @@ Pending Release Notes
 Updates / New Features
 ----------------------
 
+Documentation
+
+* Added additional examples around using the ``smqtk_core.configuration``
+  module: non-trivial constructor type configuration, and multiple-choice
+  configuration specification, generation and utilization.
+
 
 Fixes
 -----


### PR DESCRIPTION
This updates some doc-strings as well as adds to the documentation additional examples around using the ``smqtk_core.configuration`` module tools, more specifically the additional helper functions beside the ``Configurable`` mixin class.