### PR TITLE
Refer to dirs with ./ prefix

### DIFF
--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -120,11 +120,11 @@ jobs:
         uses: ./.github/actions/python-poetry-setup
 
       - name: Run Unittests
-        run: poetry run pytest --cov=smqtk_core --cov-config=.pytest.coveragerc
+        run: poetry run pytest
 
       - name: CodeCov report submission
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-          fails: coverage.xml
+          files: coverage.xml
           flags: unittests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,4 +79,4 @@ test:unittests:
   image: $IMAGE
   script:
     - *test_setup  # expand `&test_setup` anchor above into here.
-    - poetry run pytest --cov=smqtk_core --cov-config=.pytest.coveragerc
+    - poetry run pytest

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -8,7 +8,8 @@ Updates / New Features
 CI
 
 * Added use of CodeCov. Fixed/added unittests to show 100% of test code,
-  e.g. no dead-code in the tests.
+  e.g. no dead-code in the tests. CodeCov checks different coverage bars
+  for test and package scopes.
 
 Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ addopts = [
     "-lv",                  # Show local in trace-backs.
     "--doctest-modules",    # Increased verbosity.
     "--tb=long",            # Trace-back print mode.
-    "--cov=smqtk_core",     # Cover our package specifically
-    "--cov=tests",          # Also cover our tests for dead spots
+    "--cov=./smqtk_core",     # Cover our package specifically
+    "--cov=./tests",          # Also cover our tests for dead spots
     "--cov-report=term",    # Coverage report to terminal
     "--cov-report=xml:coverage.xml",    # for external tool reporting
 ]


### PR DESCRIPTION
Trying to fix why code-cov is not interpreting the `tests` coverage.