### PR TITLE
Update the publish workflow to be reusable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,13 @@ on:
       # Only run on tags with official version tag release format (e.g. v1.0.1)
       - "v[0-9].[0-9]+.[0-9]+"
 
+  # Allow use of this workflow as a reusable workflow.
+  # https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+  workflow_call:
+    secrets:
+      PYPI_TOKEN:
+        required: true
+
 defaults:
   run:
     shell: bash
@@ -17,6 +24,7 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    container: python:3.6
     if: github.repository_owner == 'Kitware'
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -38,13 +46,16 @@ jobs:
           key: python-3.6-${{ hashFiles('poetry.lock') }}
           restore-keys: |
             python-3.6-
+
       - name: Setup Environment
-        uses: ./.github/actions/python-poetry-setup
+        # Using non-relative path for correct behavior when used as a remote
+        # workflow.
+        uses: Kitware/SMQTK-Core/.github/actions/python-poetry-setup@master
 
       - name: Publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN}}
         run: |
           echo "Publishing new tag: ${{ github.ref_name }}"
-
           git checkout ${{ github.ref_name }}
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish --build

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -6,8 +6,10 @@ Updates / New Features
 
 CI
 
-* Add check for repository owner during release workflow and only
-  publish if the owner is Kitware
+* Reverted previous release automation due to unintended side-effects.
+  Created a revised publish action to more simply publish the package to pypi,
+  guarding against activating on fork of the repository.
+  This workflow has been made to be reusable by other repositories' workflows.
 
 Contribution Guide
 


### PR DESCRIPTION
Setup to allow other `smqtk-*` to reuse this workflow via a small wrapper, as opposed to copying the whole workflow.

Also update publish job to run in a known python 3.6 container.