### PR TITLE
Remove stub notes file from doc

### DIFF
--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -79,22 +79,6 @@ and functionalities.
 
 6. `Create new version release to PYPI`_
 
-Stub Pending Notes File
-^^^^^^^^^^^^^^^^^^^^^^^
-The following is the basic content that goes into the stub pending release
-notes file:
-
-.. code-block::
-
-    Pending Release Notes
-    =====================
-
-    Updates / New Features
-    ----------------------
-
-    Fixes
-    -----
-
 Tag new version
 ---------------
 Release branches should be tagged in order to record where in the git tree a


### PR DESCRIPTION
Now that the stub notes file is encoded as a template file next to the relevant script, its detailing in the release process document seems superfluous.

Intentionally not adding a release note as this falls under the purview of an existing note.