### PR TITLE
Add a line to fail publishing if the token provided is empty

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,11 @@ jobs:
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN}}
         run: |
+          if [[ -z "$POETRY_PYPI_TOKEN_PYPI" ]]
+          then
+            echo "ERROR: Input pypi token was blank. Did you forget to set the appropriate secret?"
+            exit 1
+          fi
           echo "Publishing new tag: ${{ github.ref_name }}"
           git checkout ${{ github.ref_name }}
           poetry publish --build


### PR DESCRIPTION
This is failure on the calling repository to provide a token. Without a
token the publishing will fail in a non-obvious way by requesting input
and assuming a TTY shell (which the CI is not).