### PR TITLE
Remove new override

### DIFF
--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: CodeCov report submission
         if: ${{ github.event_name != 'schedule' }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           files: coverage.xml

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -41,6 +41,10 @@ Plugin
 
 * Added a suggestion to fix `NotAModuleError`.
 
+* Removed __new__ override to prevent construction of "not usable"
+  implementations. This feature has never been observed/utilized in the wild
+  and it's removal simplifies tool interactions and use complexity.
+
 Miscellaneous
 
 * Removed CODE_OF_CONDUCT file. This is not something that we can enforce

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -19,6 +19,8 @@ CI
 
 * Reduced CodeCov report submission by skipping this step on scheduled runs.
 
+* Update code-cov action usage to use v3.
+
 Contribution Guide
 
 * Added instructions to update pending release when making a contribution.


### PR DESCRIPTION
The override of `__new__` provided functionality that, from my experience and observation, never actually made use of or added any actual security to anything. This feature came at the cost of interrupting some downstream tools (e.g. in ipython when inspecting a class with the ?-suffix) and adding complexity in how `Pluggable` needed to be used in defining interfaces (multiple inheritance and mixin UX). With the feature not being used, these costs don't make any sense any more.