### PR TITLE
Standardize RST

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,21 +2,21 @@ Installation
 ============
 
 There are two ways to get ahold of SMQTK-Core.
-The simplest is to install via the :command:`pip` command.
+The simplest is to install via the `pip <#From pip>`_ command.
 Alternatively, the source tree can be acquired and be locally developed using
 `Poetry`_.
 
-For more information on the use of `Poetry`_, follow these links fr
+For more information on the use of `Poetry`_, follow these links from
 `installation`_ and `usage`_ documentation.
 
 .. _installation: Poetry-installation_
 .. _usage: Poetry-usage_
 
 
-From :command:`pip`
--------------------
+From pip
+--------
 
-.. prompt:: bash
+.. code:: bash
 
     pip install smqtk-core
 
@@ -34,7 +34,7 @@ The following assumes `Poetry`_ is already installed.
 Quick Start
 ^^^^^^^^^^^
 
-.. prompt:: bash
+.. code:: bash
 
     cd /where/things/should/go/
     git clone https://github.com/Kitware/smqtk-core.git ./
@@ -50,19 +50,19 @@ Installing Python dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This project uses `Poetry`_ for depedency management, environment consistency,
 version management, package building and publishing to PYPI.
-Dependencies are `abstractly defined`_ in the :file:`pyproject.toml` file.
+Dependencies are `abstractly defined`_ in the ``pyproject.toml`` file.
 Additionally, `specifically pinned versions`_ are specified in the
-:file:`poetry.lock` file for *development* environment consistency.
+``poetry.lock`` file for *development* environment consistency.
 Both of these files can be found in the root of the source tree.
 
 .. _abstractly defined: Poetry-dependencies_
 .. _specifically pinned versions: Poetry-poetrylock_
 
 The following command installs both installation and development dependencies
-as specified in the :file:`pyproject.toml` file, with versions specified
-(including for transitive dependencies) in the :file:`poetry.lock` file:
+as specified in the ``pyproject.toml`` file, with versions specified
+(including for transitive dependencies) in the ``poetry.lock`` file:
 
-.. prompt:: bash
+.. code:: bash
 
     poetry install
 
@@ -70,20 +70,20 @@ as specified in the :file:`pyproject.toml` file, with versions specified
 Building the Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 The documentation for SMQTK-Core is maintained as a collection of
-`reStructuredText`_ documents in the :file:`docs/` folder of the project.
-This documentation can be processed by the :program:`Sphinx` documentation tool
+`reStructuredText`_ documents in the ``docs/`` folder of the project.
+This documentation can be processed by the ``Sphinx`` documentation tool
 into a variety of documentation formats, the most common of which is HTML.
 
-Within the :file:`docs/` directory is a Unix :file:`Makefile` (for Windows
-systems, a :file:`make.bat` file with similar capabilities exists).
-This :file:`Makefile` takes care of the work required to run :program:`Sphinx`
+Within the ``docs/`` directory is a Unix ``Makefile`` (for Windows
+systems, a ``make.bat`` file with similar capabilities exists).
+This ``Makefile`` takes care of the work required to run ``Sphinx``
 to convert the raw documentation to an attractive output format.
 For example, as shown in the quickstart, calling ``make html`` will generate
-HTML format documentation rooted at :file:`docs/_build/html/index.html`.
+HTML format documentation rooted at ``docs/_build/html/index.html``.
 
 Calling the command ``make help`` here will show the other documentation
 formats that may be available (although be aware that some of them require
-additional dependencies such as :program:`TeX` or :program:`LaTeX`)
+additional dependencies such as ``TeX`` or ``LaTeX``)
 
 
 Live Preview
@@ -93,16 +93,16 @@ While writing documentation in a mark up format such as `reStructuredText`_ it
 is very helpful to be able to preview the formatted version of the text.
 While it is possible to simply run the ``make html`` command periodically, a
 more seamless workflow of this is available.
-Within the :file:`docs/` directory is a small Python script called
-:file:`sphinx_server.py` that can simply be called with:
+Within the ``docs/`` directory is a small Python script called
+``sphinx_server.py`` that can simply be called with:
 
-.. prompt:: bash
+.. code:: bash
 
     python sphinx_server.py
 
-This will run a small process that watches the :file:`docs/` folder contents,
-as well as the source files in :file:`smqtk_core/`, for changes.
-:command:`make html` is re-run automatically when changes are detected.
+This will run a small process that watches the ``docs/`` folder contents,
+as well as the source files in ``smqtk_core/``, for changes.
+``make html`` is re-run automatically when changes are detected.
 This will serve the resulting HTML files at http://localhost:5500.
 Having this URL open in a browser will provide you with a relatively up-to-date
 preview of the rendered documentation.


### PR DESCRIPTION
I'm on the fence about submitting this as a PR. Looking at the online documentation it looks like sphinx does render the existing RST correctly, but the reason I made this change was I was viewing the documentation locally and it was throwing a lot of errors when trying to render things. I switched some of the constructs to standard RST format, so it renders in simple viewers, but it may not make sense to prefer that over the sphinx extended version, and perhaps I should just try to find a viewer that supports that.

Anyway, pushing this up for review / discussion. 